### PR TITLE
Update README.md

### DIFF
--- a/highlighter/README.md
+++ b/highlighter/README.md
@@ -25,7 +25,7 @@ You will need to install the following:
 * **Git**: If you have cloned this project already then you can skip this! GitHub has excellent guides for [Windows](https://help.github.com/articles/set-up-git/#platform-windows), [OS X](https://help.github.com/articles/set-up-git/#platform-mac) and [Linux](https://help.github.com/articles/set-up-git/#platform-linux).
 * **Python27**: Before you will be able to run these tests you will need to have [Python 2.7.12](https://www.python.org/downloads/release/python-2712/) installed.
 * **Python36**: Before you will be able to run these tests you will need to have [Python 3.6.1](https://www.python.org/downloads/release/python-361/) installed.
-* **Tox**: You will need to [install Tox](https://testrun.org/tox/latest/install.html) to manage the virtual environments and run the tests.
+* **Tox**: You will need to [install Tox](https://tox.readthedocs.io/en/latest/install.html) to manage the virtual environments and run the tests.
 * **Geckodriver**: To run the tests in Firefox you will need to [download Geckodriver](https://github.com/mozilla/geckodriver/releases) and add it to your PATH. For example, `export PATH=$PATH:/directory/containing/geckodriver/`.
 
 ### Running tests locally


### PR DESCRIPTION
install Tox link fixed: https://tox.readthedocs.io/en/latest/install.html

closes #21 